### PR TITLE
balloon: add free page reporting support

### DIFF
--- a/balloon.go
+++ b/balloon.go
@@ -27,7 +27,7 @@ type BalloonOpt func(*models.Balloon)
 // NewBalloonDevice will return a new BalloonDevice.
 func NewBalloonDevice(amountMib int64, deflateOnOom bool, opts ...BalloonOpt) BalloonDevice {
 	b := models.Balloon{
-		AmountMib:     &amountMib,
+		AmountMib:    &amountMib,
 		DeflateOnOom: &deflateOnOom,
 	}
 
@@ -47,6 +47,15 @@ func (b BalloonDevice) Build() models.Balloon {
 func WithStatsPollingIntervals(statsPollingIntervals int64) BalloonOpt {
 	return func(d *models.Balloon) {
 		d.StatsPollingIntervals = statsPollingIntervals
+	}
+}
+
+// WithFreePageReporting is a functional option which enables free page reporting
+// on the balloon device. When enabled, the guest kernel reports freed pages to the
+// hypervisor, which MADV_DONTNEEDs them to reduce host RSS.
+func WithFreePageReporting(enabled bool) BalloonOpt {
+	return func(d *models.Balloon) {
+		d.FreePageReporting = enabled
 	}
 }
 

--- a/client/models/balloon.go
+++ b/client/models/balloon.go
@@ -40,6 +40,12 @@ type Balloon struct {
 
 	// Interval in seconds between refreshing statistics. A non-zero value will enable the statistics. Defaults to 0.
 	StatsPollingIntervals int64 `json:"stats_polling_interval_s,omitempty"`
+
+	// Whether the balloon device should enable free page reporting. If enabled,
+	// the guest kernel will report freed pages to the hypervisor, which will
+	// MADV_DONTNEED them to reduce host RSS. Requires CONFIG_PAGE_REPORTING=y
+	// in the guest kernel and Firecracker >= v1.14.0.
+	FreePageReporting bool `json:"free_page_reporting,omitempty"`
 }
 
 // Validate validates this balloon

--- a/handlers.go
+++ b/handlers.go
@@ -283,11 +283,11 @@ var ConfigMmdsHandler = Handler{
 
 // NewCreateBalloonHandler is a named handler that put a memory balloon into the
 // firecracker process.
-func NewCreateBalloonHandler(amountMib int64, deflateOnOom bool, StatsPollingIntervals int64) Handler {
+func NewCreateBalloonHandler(amountMib int64, deflateOnOom bool, statsPollingIntervals int64, opts ...BalloonOpt) Handler {
 	return Handler{
 		Name: CreateBalloonHandlerName,
 		Fn: func(ctx context.Context, m *Machine) error {
-			return m.CreateBalloon(ctx, amountMib, deflateOnOom, StatsPollingIntervals)
+			return m.CreateBalloonWithOpts(ctx, amountMib, deflateOnOom, statsPollingIntervals, opts...)
 		},
 	}
 }

--- a/machine.go
+++ b/machine.go
@@ -1204,6 +1204,27 @@ func (m *Machine) CreateBalloon(ctx context.Context, amountMib int64, deflateOnO
 	return nil
 }
 
+// CreateBalloonWithOpts creates a balloon device using BalloonOpt functional
+// options to configure fields like FreePageReporting that aren't exposed as
+// direct parameters.
+func (m *Machine) CreateBalloonWithOpts(ctx context.Context, amountMib int64, deflateOnOom bool, statsPollingIntervals int64, opts ...BalloonOpt) error {
+	balloon := models.Balloon{
+		AmountMib:             &amountMib,
+		DeflateOnOom:          &deflateOnOom,
+		StatsPollingIntervals: statsPollingIntervals,
+	}
+	for _, opt := range opts {
+		opt(&balloon)
+	}
+	_, err := m.client.PutBalloon(ctx, &balloon)
+	if err != nil {
+		m.logger.Errorf("Create balloon device failed: %s", err)
+		return err
+	}
+	m.logger.Debug("Created balloon device successfully")
+	return nil
+}
+
 // GetBalloonConfig gets the current balloon device configuration.
 func (m *Machine) GetBalloonConfig(ctx context.Context) (models.Balloon, error) {
 	var balloonConfig models.Balloon


### PR DESCRIPTION
## Summary
- Add `FreePageReporting` field to `Balloon` model (`client/models/balloon.go`)
- Add `WithFreePageReporting` functional option (`balloon.go`)
- Update `NewCreateBalloonHandler` to accept `BalloonOpt` variadic args (`handlers.go`)
- Add `CreateBalloonWithOpts` method that applies `BalloonOpt` options before calling `PutBalloon` (`machine.go`)

This enables callers to configure `VIRTIO_BALLOON_F_REPORTING` via Firecracker >= v1.14.0, which makes the guest kernel report freed pages to the hypervisor so it can `MADV_DONTNEED` them and reduce host RSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/useblacksmith/firecracker-go-sdk/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
